### PR TITLE
Do not mess with global $COMP_WORDBREAKS variable

### DIFF
--- a/template
+++ b/template
@@ -3,13 +3,13 @@ _%%SCRIPT%%()
 {
     local cur prev coms opts
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    _get_comp_words_by_ref -n : cur prev cword
     coms="%%COMMANDS%%"
     opts="%%SHARED_OPTIONS%%"
 
-    if [[ ${COMP_CWORD} = 1 ]] ; then
+    if [[ $cword = 1 ]] ; then
         COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
         return 0
     fi
 
@@ -22,4 +22,3 @@ _%%SCRIPT%%()
 }
 
 complete -o default -F _%%SCRIPT%% %%SCRIPT%%
-COMP_WORDBREAKS=${COMP_WORDBREAKS//:}


### PR DESCRIPTION
Completion scripts should not modify the global $COMP_WORDBREAKS variable. This may break other completion rules, and this completion rule is broken if some other script modifies the variable.

See http://stackoverflow.com/questions/10528695/how-to-reset-comp-wordbreaks-without-effecting-other-completion-script