### PR TITLE
remove whitespace at the end of line

### DIFF
--- a/symfony-autocomplete
+++ b/symfony-autocomplete
@@ -164,6 +164,7 @@ SWITCHCASE;
                 $switchCase
             )."\n        ";
         }
+        $switchContent = rtrim($switchContent, ' ');
 
         // dump
         $template = file_get_contents(__DIR__.'/templates/cached.bash.tpl');


### PR DESCRIPTION
when generating the switch-case block, the last line did contain spaces
which creates a whitespace error marking when checking in files under
git version control.