### PR TITLE
Optimize by run single list --format=xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "symfony/console": "^2.5|3.*",
-        "symfony/process": "^2.3|3.*"
+        "symfony/process": "^2.3|3.*",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "symfony/console": "2.8.*"

--- a/src/DumpCommand.php
+++ b/src/DumpCommand.php
@@ -92,7 +92,7 @@ class DumpCommand extends Command
         foreach ($xml->xpath('/symfony/commands/command') as $xmlCommand) {
             $command = (string) $xmlCommand['name'];
             $commands[] = $command;
-            $commandsDescriptions[$command] = !empty($xmlCommand->description) ? $xmlCommand->description : null;
+            $commandsDescriptions[$command] = !empty($xmlCommand->description) ? strip_tags($xmlCommand->description) : null;
             $commandsOptionsDescriptions[$command] = array();
             $commandOptions = array();
             foreach ($xmlCommand->xpath('options/option') as $commandOption) {


### PR DESCRIPTION
The existing code is very slow with more than a couple of commands (especially so on a Docker for Mac osxfs host volume mount).

The symfony/console library supports fetching a single combined xml of all commands, so using this reduces the number of console command runs to one, massively speeding it up.