### PR TITLE
Explicitly use list action when finding commands

### DIFF
--- a/src/DumpCommand.php
+++ b/src/DumpCommand.php
@@ -73,7 +73,7 @@ class DumpCommand extends Command
         $scriptOptions = $input->getOption('script-options');
 
         // find all commands
-        $process = new Process($script . ' ' . $scriptOptions . ' --format=xml');
+        $process = new Process($script . ' list ' . $scriptOptions . ' --format=xml');
         $process->run();
         if (!$process->isSuccessful()) {
             throw new \RuntimeException($process->getErrorOutput());


### PR DESCRIPTION
Some symfony console apps override the default "no action" action, rather than giving a list of commands. Explicitly calling list fixes that