### PR TITLE
Artisan and Deployer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ here is a non-exhaustive list :
 * behat
 * phpspec
 * robo
+* deployer
+* laravel's artisan

--- a/src/DumpCommand.php
+++ b/src/DumpCommand.php
@@ -53,6 +53,8 @@ class DumpCommand extends Command
                     'phpspec',
                     'behat',
                     'robo',
+                    'dep',
+                    'artisan',
                 );
             }
 

--- a/tests/fixtures/bash/default.txt
+++ b/tests/fixtures/bash/default.txt
@@ -48,3 +48,5 @@ complete -o default -F _symfony php-cs-fixer
 complete -o default -F _symfony phpspec
 complete -o default -F _symfony behat
 complete -o default -F _symfony robo
+complete -o default -F _symfony dep
+complete -o default -F _symfony artisan


### PR DESCRIPTION
For convenience, this PR adds built-in support for 
* Deployer — `dep` command; https://deployer.org/ ,
* Laravel's console — `artisan`.