### PR TITLE
DumpCommand: $_SERVER['SHELL'] can be not set

### DIFF
--- a/src/DumpCommand.php
+++ b/src/DumpCommand.php
@@ -20,7 +20,7 @@ class DumpCommand extends Command
                 new InputOption('script-options', null, InputOption::VALUE_REQUIRED, "Options to be passed to the script."),
                 new InputOption('aliases', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, "Extra aliases to be used."),
                 new InputOption('disable-default-tools', null, InputOption::VALUE_NONE),
-                new InputOption('shell', null, InputOption::VALUE_REQUIRED, 'Shell type ("bash", "fish" or "zsh")', basename($_SERVER['SHELL'])),
+                new InputOption('shell', null, InputOption::VALUE_REQUIRED, 'Shell type ("bash", "fish" or "zsh")', isset($_SERVER['SHELL']) ? basename($_SERVER['SHELL']) : null),
             ))
             ->setDescription('Dumps shell autocompletion for any executable based on a Symfony Console Application.')
         ;


### PR DESCRIPTION
When installing the autocomplete in particular environments like Dockerfile, `SHELL` can be absent from environment variables, and the command outputs this notice:

```
Notice: Undefined index: SHELL in ./src/DumpCommand.php on line 23

Call Stack:
    0.0003     396400   1. {main}() ./bin/symfony-autocomplete:0
    0.0167     789144   2. Bamarni\Symfony\Console\Autocomplete\DumpCommand->__construct() ./bin/symfony-autocomplete:48
    0.0174     842448   3. Bamarni\Symfony\Console\Autocomplete\DumpCommand->configure() ./vendor/symfony/console/Command/Command.php:63
```

I wasn't able to test the commit against Travis because Travis always populates `SHELL`.