### PR TITLE
Don't test EOL'ed PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - hhvm
-  - nightly
 
 env:
   - COMPOSER_OPTIONS="--prefer-source"
   - COMPOSER_OPTIONS="--prefer-source --prefer-lowest"
-
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: nightly
-
-fast_finish: true
 
 install:
   - git clone https://github.com/sstephenson/bats.git /tmp/bats


### PR DESCRIPTION
This updates the Travis CI test matrix to remove PHP versions which have
reached EOL.

https://www.php.net/supported-versions.php