### PR TITLE
Support bin/roadiz console

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ here is a non-exhaustive list :
 * robo
 * deployer
 * laravel's artisan
+* roadiz

--- a/src/DumpCommand.php
+++ b/src/DumpCommand.php
@@ -55,6 +55,7 @@ class DumpCommand extends Command
                     'robo',
                     'dep',
                     'artisan',
+                    'roadiz',
                 );
             }
 

--- a/tests/fixtures/bash/default.txt
+++ b/tests/fixtures/bash/default.txt
@@ -50,3 +50,4 @@ complete -o default -F _symfony behat
 complete -o default -F _symfony robo
 complete -o default -F _symfony dep
 complete -o default -F _symfony artisan
+complete -o default -F _symfony roadiz


### PR DESCRIPTION
*Roadiz CMS* uses a dedicated CLI entry point name `bin/roadiz` instead of `bin/console`. 