### PR TITLE
Symfony 4.4/5.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Shell completion for Symfony Console based scripts",
     "license": "MIT",
     "require": {
-        "symfony/console": "^2.5|^3|^4",
-        "symfony/process": "^2.5|^3|^4",
+        "symfony/console": "^2.5|^3|^4|^5",
+        "symfony/process": "^2.5|^3|^4|^5",
         "ext-simplexml": "*"
     },
     "require-dev": {


### PR DESCRIPTION
With Symfony 4.4 2 methods changed which is throwing a deprecation warning and with Symfony 5.0 the support dropped:

- changed Process constructor (only possible to pass a string array instead of a plain string)
- Command::execute() must return `int` now

e.g.
```
PHP Fatal error:  Uncaught TypeError: Return value of "Bamarni\Symfony\Console\Autocomplete\DumpCommand::execute()" must be of the type int, NULL returned. in /www/foe/libs/external/symfony/console/Command/Command.php:258
Stack trace:
#0 /www/foe/libs/external/symfony/console/Application.php(925): Symfony\Component\Console\Command\Command->run()
#1 /www/foe/libs/external/symfony/console/Application.php(265): Symfony\Component\Console\Application->doRunCommand()
#2 /www/foe/libs/external/symfony/console/Application.php(141): Symfony\Component\Console\Application->doRun()
#3 /www/foe/libs/external/bamarni/symfony-console-autocomplete/bin/symfony-autocomplete(49): Symfony\Component\Console\Application->run()
#4 {main}
```