### PR TITLE
Start migration from Travis-CI to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  travis-ci-migration:
+    name: PHP ${{ matrix.php-version }} - ${{ matrix.run-job }}
+    runs-on: ${{ matrix.machine }}
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['ubuntu-16.04']
+        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        run-job: ['env.1', 'env.2']
+        experimental: [false]
+        include:
+          - machine: 'ubuntu-18.04'
+            php-version: '8.0'
+            run-job: 'env.1'
+            experimental: true
+          - machine: 'ubuntu-18.04'
+            php-version: '8.0'
+            run-job: 'env.2'
+            experimental: true
+          - machine: 'ubuntu-18.04'
+            php-version: '8.1'
+            run-job: 'env.1'
+            experimental: true
+          - machine: 'ubuntu-18.04'
+            php-version: '8.1'
+            run-job: 'env.2'
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - uses: ktomk/run-travis-yml@v1
+        with:
+          run-job: ${{ matrix.run-job }}
+          allow-failure: ${{ matrix.experimental }}


### PR DESCRIPTION
Porting jobs matrix by the two build environs (composer /--prefer-lowest)
and PHP versions 7.0 - 7.4.

Straight forward port from .travis.yml with the help of the
shivammathur/setup-php and ktomk/run-travis-yml Github Actions.

Additionally adding PHP 8.0 and nightly (8.1 @ shivammathur/setup-php).

Different is the Ubuntu version: Upstream was on Xenial (for base-line)
and on Trusty (for PHP 8.0 PR). Picking Xenial (Trusty is n/a on
Github).

Rationale is that the project is still running on travis-ci.org which
is shutting down. And: PHP 8.0 support (different issue).

PHP 8.0/8.1 fail by default, as not the PHP 8.0 PR nor already merged.

Further: bamarni/symfony-console-autocomplate is a dependency in magerun
and we have interest in a working CI and PHP 8.0 compatibility upstream.