### PR TITLE
Support PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
 
+dist: trusty
+
 php:
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - nightly
 
 env:
   - COMPOSER_OPTIONS="--prefer-source"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 
-dist: trusty
-
 php:
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
+  - 8.0snapshot
   - nightly
 
 env:
@@ -28,3 +26,8 @@ script:
 
 notifications:
   email: false
+
+jobs:
+  fast_finish: true
+  allow_failures:
+  - php: '8.0' # php 8.0 missing on travis <https://travis-ci.community/t/php-8-0-missing/10132>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Shell completion for Symfony Console based scripts",
     "license": "MIT",
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "ext-simplexml": "*",
         "symfony/console": "^2.5|^3|^4|^5",
         "symfony/process": "^2.5|^3|^4|^5"


### PR DESCRIPTION
Based on https://github.com/bamarni/symfony-console-autocomplete/pull/60

Just checking if travis has php8 yet, otherwise adding the suggestion to ignore its failures.