### PR TITLE
fix: symfony/console v6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         machine: ['ubuntu-18.04']
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-version: ['7.1', '7.2', '7.3', '7.4']
         run-job: ['env.1', 'env.2']
         experimental: [false]
         include:

--- a/bin/symfony-autocomplete
+++ b/bin/symfony-autocomplete
@@ -1,10 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+use Bamarni\Symfony\Console\Autocomplete\DumpCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use Bamarni\Symfony\Console\Autocomplete\DumpCommand;
 
 if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
     require_once $autoload;
@@ -23,12 +24,12 @@ class Application extends BaseApplication
         parent::__construct();
     }
 
-    protected function getCommandName(InputInterface $input)
+    protected function getCommandName(InputInterface $input): ?string
     {
         return $this->command->getName();
     }
 
-    protected function getDefaultCommands()
+    protected function getDefaultCommands(): array
     {
         $defaultCommands = parent::getDefaultCommands();
         $defaultCommands[] = $this->command;
@@ -36,7 +37,7 @@ class Application extends BaseApplication
         return $defaultCommands;
     }
 
-    public function getDefinition()
+    public function getDefinition(): InputDefinition
     {
         $inputDefinition = parent::getDefinition();
         $inputDefinition->setArguments();

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Shell completion for Symfony Console based scripts",
     "license": "MIT",
     "require": {
-        "php": "^7.0|^8.0",
+        "php": "^7.1|^8.0",
         "ext-simplexml": "*",
         "symfony/console": "^2.5|^3|^4|^5|^6",
         "symfony/process": "^2.5|^3|^4|^5|^6"


### PR DESCRIPTION
Since `?string` is used, PHP 7.0 support will be dropped. 

---

Fixes https://github.com/bamarni/symfony-console-autocomplete/issues/70