### PR TITLE
Fix local variable affecting shell environment outside of function

### DIFF
--- a/resources/bash/cached.php
+++ b/resources/bash/cached.php
@@ -1,6 +1,6 @@
 _<?php echo $vars['script'] ?>()
 {
-    local cur script coms opts com
+    local cur script coms opts com words
     COMPREPLY=()
     _get_comp_words_by_ref -n : cur words
 

--- a/resources/bash/default.php
+++ b/resources/bash/default.php
@@ -1,6 +1,6 @@
 _symfony()
 {
-    local cur script com opts
+    local cur script com opts words
     COMPREPLY=()
     _get_comp_words_by_ref -n : cur words
 

--- a/tests/fixtures/bash/cached.txt
+++ b/tests/fixtures/bash/cached.txt
@@ -1,6 +1,6 @@
 _acme()
 {
-    local cur script coms opts com
+    local cur script coms opts com words
     COMPREPLY=()
     _get_comp_words_by_ref -n : cur words
 

--- a/tests/fixtures/bash/default.txt
+++ b/tests/fixtures/bash/default.txt
@@ -1,6 +1,6 @@
 _symfony()
 {
-    local cur script com opts
+    local cur script com opts words
     COMPREPLY=()
     _get_comp_words_by_ref -n : cur words
 


### PR DESCRIPTION
After tab-completing, the `$words` array would persist and possibly affect other things.

Using `local` keeps it inside the function scope.