### PR TITLE
chore(ci): add build manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['ubuntu-18.04']
-        php-version: ['7.1', '7.2', '7.3', '7.4']
+        machine: ['ubuntu-20.04']
+        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         run-job: ['env.1', 'env.2']
         experimental: [false]
         include:
-          - machine: 'ubuntu-18.04'
-            php-version: '8.0'
+          - machine: 'ubuntu-20.04'
+            php-version: '8.2'
             run-job: 'env.1'
             experimental: true
-          - machine: 'ubuntu-18.04'
-            php-version: '8.0'
-            run-job: 'env.2'
-            experimental: true
-          - machine: 'ubuntu-18.04'
-            php-version: '8.1'
-            run-job: 'env.1'
-            experimental: true
-          - machine: 'ubuntu-18.04'
-            php-version: '8.1'
+          - machine: 'ubuntu-20.04'
+            php-version: '8.2'
             run-job: 'env.2'
             experimental: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-composer.lock
-vendor/
+*.cached*
+/composer.lock
+/vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+BATS_GIT := https://github.com/sstephenson/bats.git
+BATS_TMP := /tmp/bats
+COMPOSER_COMMAND ?= composer
+COMPOSER_OPTIONS ?= --prefer-source
+GIT ?= git
+PHP ?= php
+
+COMPOSER_EXECUTABLE := $(shell command -v $(COMPOSER_COMMAND) 2> /dev/null)
+COMPOSER_CMD := $(PHP) $(COMPOSER_EXECUTABLE)
+export COMPOSER_VENDOR_DIR := vendor-$(PHP).cached
+export COMPOSER := composer-$(PHP).cached.json
+
+export PATH := $(PWD)/bin:$(dir $(BATS_TMP))local/bin:$(PWD)/tests/fixtures:$(PATH)
+
+
+.PHONY : all
+all : install test
+
+.PHONY : test
+test : $(dir $(BATS_TMP))local/bin/bats vendor
+	bats tests
+
+.PHONY : install
+install : $(dir $(BATS_TMP))local/bin/bats vendor
+	@$(PHP) --version | head -1
+	@$(COMPOSER_CMD) --version
+	@bats --version
+
+$(dir $(BATS_TMP))local/libexec/bats $(dir $(BATS_TMP))local/bin/bats : $(BATS_TMP)/.git/HEAD
+	mkdir -p $(dir $(BATS_TMP))local
+	bash $(BATS_TMP)/install.sh $(dir $(BATS_TMP))local
+	bats --version
+	touch $(@)
+
+$(BATS_TMP)/.git/HEAD :
+	$(GIT) clone $(BATS_GIT) $(BATS_TMP)
+
+.PHONY : vendor
+vendor : $(COMPOSER) $(COMPOSER_VENDOR_DIR)/composer/installed.json
+
+composer-%.cached.json : composer.json
+	rm -f $@
+	cp $< $@
+
+composer.lock : $(COMPOSER_VENDOR_DIR)/composer/installed.json
+	touch $@
+
+$(COMPOSER_VENDOR_DIR)/composer/installed.json : composer.json
+	$(COMPOSER_CMD) update $(COMPOSER_OPTIONS)
+	touch $@
+
+.PHONY : clean
+clean :
+	rm -rf -- $(BATS_TMP) $(dir $(BATS_TMP))local
+	git clean -ffx vendor-*.cached composer-*.cached*


### PR DESCRIPTION
to more easily build the project locally, add GNU make as build manager, just `make`.

current workflow is aligned with configuration in travis.yml, the php command defaults to `php` and can be configured with `PHP=php8.2`.

the build is leaving the project tree for `bats` which goes to `/tmp/bats`  and `/tmp/local`, which is from the current configuration.

github workflow configuration also updated to the current PHP version and deprecation noise reduced for the remote dependencies.