### PR TITLE
Patch/composer vendor dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-*.cached*
+*.cache*
 /composer.lock
 /vendor/

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ PHP ?= php
 
 COMPOSER_EXECUTABLE := $(shell command -v $(COMPOSER_COMMAND) 2> /dev/null)
 COMPOSER_CMD := $(PHP) $(COMPOSER_EXECUTABLE)
-export COMPOSER_VENDOR_DIR := vendor-$(PHP).cached
-export COMPOSER := composer-$(PHP).cached.json
+export COMPOSER_VENDOR_DIR := vendor-$(PHP).cache
+export COMPOSER := composer-$(PHP).cache.json
 
 export PATH := $(PWD)/bin:$(dir $(BATS_TMP))local/bin:$(PWD)/tests/fixtures:$(PATH)
 
@@ -38,7 +38,7 @@ $(BATS_TMP)/.git/HEAD :
 .PHONY : vendor
 vendor : $(COMPOSER) $(COMPOSER_VENDOR_DIR)/composer/installed.json
 
-composer-%.cached.json : composer.json
+composer-%.cache.json : composer.json
 	rm -f $@
 	cp $< $@
 
@@ -52,4 +52,4 @@ $(COMPOSER_VENDOR_DIR)/composer/installed.json : composer.json
 .PHONY : clean
 clean :
 	rm -rf -- $(BATS_TMP) $(dir $(BATS_TMP))local
-	git clean -ffx vendor-*.cached composer-*.cached*
+	git clean -ffx vendor-*.cache* composer-*.cache*

--- a/bin/symfony-autocomplete
+++ b/bin/symfony-autocomplete
@@ -6,11 +6,27 @@ if (function_exists('ini_set')) {
     ini_set('display_errors', 'stderr');
 }
 
-if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
-    require_once $autoload;
-} else {
-    require_once __DIR__.'/../vendor/autoload.php';
-}
+(/* require vendor autoload file (Composer) */ static function () {
+    $includeIfExists = static function ($file) {
+        /** @noinspection UsingInclusionOnceReturnValueInspection intended */
+        return file_exists($file) ? include_once($file) : false;
+    };
+    if ((!$includeIfExists(
+                __DIR__ . '/../../../autoload.php'
+            ) &&
+            empty($_SERVER['COMPOSER_VENDOR_DIR'])) ||
+        (!$includeIfExists(
+                $_SERVER['COMPOSER_VENDOR_DIR'] . '/autoload.php'
+            ) &&
+            !$includeIfExists(
+                __DIR__ . '/../' . $_SERVER['COMPOSER_VENDOR_DIR'] .
+                '/autoload.php'
+            )
+        )
+    ) {
+        require_once __DIR__ . '/../vendor/autoload.php';
+    }
+})();
 
 use Bamarni\Symfony\Console\Autocomplete\Application;
 

--- a/tests/fixtures/acme
+++ b/tests/fixtures/acme
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/../../vendor/autoload.php';
+require __DIR__.'/../../' . ($_SERVER['COMPOSER_VENDOR_DIR'] ?? 'vendor') . '/autoload.php';
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;


### PR DESCRIPTION
fix symfony-autocomplete composer vendor

bin/symfony-autocomplete did not honor COMPOSER_VENDOR_DIR and treated it as if it is the default value "vendor" only.

however it is part of the composer install protocol and required for the bin-stubs autoloading.  it should not be hard-encoded to the default value only.

fix is to use COMPOSER_VENDOR_DIR as absolute path, as relative path to PWD and as relative path to bin/symfony-autocomplete given the first attempt to try requiring from __DIR__.'/../../../autoload.php' failed.

NOTE: use of include_once instead of require_once is intended here, the EA inspection is misleading on it as _once was and still is intended.

this is similar for "acme" in tests, but with the difference that during build time we insist to know that COMPOSER_VENDOR_DIR is always relative to the project root, YMMV.

report: #76